### PR TITLE
fix(function): give scryfall index updater 8GB + raised V8 heap

### DIFF
--- a/~github/workflows/deploy-function.yml
+++ b/~github/workflows/deploy-function.yml
@@ -38,13 +38,18 @@ jobs:
           folder-id: ${{ secrets.YC_FOLDER_ID }}
           function-name: scryfall-index-updater
           runtime: nodejs22
-          memory: 2GB
+          # Building the full Scryfall all_cards FlexSearch index in memory needs
+          # ~8 GB heap (cf. the update-index script's --max_old_space_size=8192);
+          # 2 GB OOM-killed the runtime (signal 9). NODE_OPTIONS raises the V8
+          # heap so it actually uses the 8 GB container.
+          memory: 8GB
           entrypoint: index.updater
           execution-timeout: 600
           service-account: ${{ secrets.YC_FUNCTION_SA_ID }}
           environment: |
             AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            NODE_OPTIONS=--max-old-space-size=7168
           source-root: build/function
 
 # One-time manual setup (do NOT automate — these are stateful resources):


### PR DESCRIPTION
## Summary

The `scryfall-index-updater` Cloud Function was provisioned and deployed to Yandex Cloud, but the first live invoke was **OOM-killed** (`runtime pid: killed by signal 9`) at the scaffolded 2 GB while building the full `all_cards` FlexSearch index in memory.

That workload historically needs ~8 GB of heap — the `update-index` npm script runs `node --max_old_space_size=8192`. This bumps the function to **8 GB** (the Yandex Cloud Functions max) and sets `NODE_OPTIONS=--max-old-space-size=7168` so V8 actually grows its heap into the larger container (the crash was a cgroup OOM, not a V8 heap abort, so both the container size and the heap ceiling had to move).

Only `deploy-function.yml` changes — keeps the CI-deployed config in sync with the version that was hand-deployed during provisioning, so a future CI run won't revert to 2 GB.

## Verified

Live invoke after the bump succeeded end to end:
- runtime no longer OOM-killed
- `index.json` rebuilt and uploaded to bucket `tuktuk` (20.0 MB, **33 754** cards, en/ru bilingual entries with scryfallId)
- output validated as well-formed FlexSearch export (`reg` / `search.*` / `store`)

The prod index was ~2 months stale (last built 2026-04-19) since the nightly job had never been deployed; it is now fresh.

## Note

CI auto-deploy needs 5 GitHub Actions secrets that aren't set yet (`YC_SA_KEY_JSON`, `YC_FOLDER_ID`, `YC_FUNCTION_SA_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) — handled out-of-band. Until then the function runs on its nightly timer trigger (`update-scryfall-index`, 04:17 UTC); this workflow is the path for future code-driven redeploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)