### PR TITLE
feat(function): skip index rebuild when Scryfall bulk is unchanged

### DIFF
--- a/tools/generator/scryfall/generate.ts
+++ b/tools/generator/scryfall/generate.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
-import { loadJson } from './loadJson';
+import { loadJson, getBulkInfo, BulkInfo } from './loadJson';
 import { createProgressStream } from './progress';
-import { uploadToS3 } from './uploadToS3';
+import { uploadToS3, getStoredUpdatedAt } from './uploadToS3';
 import { createIndexStream, IndexPayload } from './generateIndex';
 import { readJson } from './readJson';
 import { createSchemaStream } from './generateSchema';
@@ -21,8 +21,24 @@ export const generate = (opts: GenerateOpts) => {
         const shouldReadData = !isCloud && (opts.slim || opts.local);
         const shouldUpload = opts.upload;
 
+        // Throttle: only rebuild when Scryfall's bulk has actually changed since
+        // the index.json we last uploaded (nightly cloud path only). On unchanged
+        // days this skips the ~2 GB download and the in-memory rebuild entirely.
+        let bulkInfo: BulkInfo | undefined;
+        if (!shouldReadData) {
+            bulkInfo = await getBulkInfo();
+            if (isCloud) {
+                const stored = await getStoredUpdatedAt();
+                if (stored && stored === bulkInfo.updatedAt) {
+                    console.log(`Index already current (scryfall updated_at=${bulkInfo.updatedAt}); skipping rebuild`);
+                    resolve();
+                    return;
+                }
+            }
+        }
+
         const localPath = opts.slim ? './generated/data.json' : './generated/data.json';
-        const { stream: dataStream, total } = await (shouldReadData ? readJson(localPath) : loadJson());
+        const { stream: dataStream, total } = await (shouldReadData ? readJson(localPath) : loadJson(bulkInfo));
         shouldReadData ? console.log(`Reading ${localPath}`) : console.log('Downloading');
 
         const rawDataStream = new PassThrough({ allowHalfOpen: false, objectMode: true });
@@ -74,7 +90,10 @@ export const generate = (opts: GenerateOpts) => {
                     const body = isCloud && indexPayload
                         ? JSON.stringify(indexPayload.index)
                         : fs.readFileSync('./generated/index/index.json');
-                    await uploadToS3(body);
+                    const metadata = bulkInfo
+                        ? { 'scryfall-updated-at': bulkInfo.updatedAt }
+                        : undefined;
+                    await uploadToS3(body, metadata);
                     console.log('Success');
                 }
                 resolve();

--- a/tools/generator/scryfall/loadJson.ts
+++ b/tools/generator/scryfall/loadJson.ts
@@ -1,21 +1,39 @@
 import axios from "axios";
 
-export const loadJson = async () => {
+export interface BulkInfo {
+    // Scryfall regenerates the bulk file periodically; updated_at changes only
+    // when it actually does, so it doubles as the index's freshness watermark.
+    updatedAt: string;
+    downloadUri: string;
+    size: number;
+}
+
+export const getBulkInfo = async (): Promise<BulkInfo> => {
     const { data: bulk } = await axios({
         url: 'https://api.scryfall.com/bulk-data',
         method: 'get',
-    })
+    });
 
-    const { download_uri: allCardsUrl, compressed_size } = bulk.data.find(({ type }) => type === 'all_cards');
+    const allCards = bulk.data.find(({ type }) => type === 'all_cards');
+
+    return {
+        updatedAt: allCards.updated_at,
+        downloadUri: allCards.download_uri,
+        size: allCards.size,
+    };
+};
+
+export const loadJson = async (info?: BulkInfo) => {
+    const { downloadUri, size } = info ?? (await getBulkInfo());
 
     const { data, headers } = await axios({
-        url: allCardsUrl,
+        url: downloadUri,
         method: 'GET',
         responseType: 'stream',
     });
 
     return {
         stream: data,
-        total: headers['content-length'] as string | number, // || compressed_size,
+        total: (headers['content-length'] as string | number) ?? size,
     }
 };

--- a/tools/generator/scryfall/uploadToS3.ts
+++ b/tools/generator/scryfall/uploadToS3.ts
@@ -1,7 +1,26 @@
 import { S3Client } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
+import axios from 'axios';
 
-export const uploadToS3 = async (body: Buffer | string) => {
+const BUCKET = 'tuktuk';
+const KEY = 'index.json';
+const PUBLIC_URL = `https://storage.yandexcloud.net/${BUCKET}/${KEY}`;
+const WATERMARK_HEADER = 'x-amz-meta-scryfall-updated-at';
+
+// Read the Scryfall updated_at we stamped onto the last uploaded index.json.
+// index.json is public-read, so a plain HEAD needs no S3 credentials (the SA's
+// storage.uploader role does not grant read). Missing object / header / network
+// error => undefined, i.e. "unknown" => caller rebuilds.
+export const getStoredUpdatedAt = async (): Promise<string | undefined> => {
+    try {
+        const { headers } = await axios.head(PUBLIC_URL);
+        return headers[WATERMARK_HEADER] as string | undefined;
+    } catch {
+        return undefined;
+    }
+};
+
+export const uploadToS3 = async (body: Buffer | string, metadata?: Record<string, string>) => {
     const s3 = new S3Client({
         credentials: {
             accessKeyId: process.env.AWS_ACCESS_KEY_ID,
@@ -15,9 +34,10 @@ export const uploadToS3 = async (body: Buffer | string) => {
             client: s3,
             params: {
                 Body: body,
-                Key: 'index.json',
-                Bucket: 'tuktuk',
+                Key: KEY,
+                Bucket: BUCKET,
                 ACL: 'public-read',
+                Metadata: metadata,
             },
         });
         const data = await upload.done();


### PR DESCRIPTION
## Summary

The nightly `scryfall-index-updater` function re-downloaded the **~2.5 GB** `all_cards` bulk and rebuilt the entire FlexSearch index on every run — even on days Scryfall hadn't regenerated the dump. This throttles it on Scryfall's own `updated_at`.

**How:**
- `getBulkInfo()` reads `all_cards` `updated_at` / `download_uri` / `size` from the cheap `/bulk-data` JSON (no big download).
- On upload, `updated_at` is stamped as `x-amz-meta-scryfall-updated-at` metadata on `index.json`.
- At the start of each **cloud** run, that watermark is read back via a plain `HEAD` on the public `index.json` URL and compared to the current bulk. Match → log `Index already current …; skipping rebuild` and return — **no 2.5 GB download, no rebuild, no upload**.

**Design notes:**
- Reading the watermark via the public HEAD needs **no new IAM** — `index.json` is public-read, and the function's `storage.uploader` role can't `GetObject` anyway. Writing it rides the existing `PutObject`.
- Gate is **cloud-path only**; the manual CLI (`--local` / `--upload`) still always rebuilds, so a force-rebuild is just a manual run.
- Missing watermark (first run, or current prod index which predates this) → rebuild, then stamp.

## Verified

- Build matrix green: `npm run build`, `npm test` (12/12), `npm run build:function`, `docker compose build`.
- Read-only data check: Scryfall `all_cards.updated_at` parses (`2026-06-12T09:25:51Z`); current `index.json` has no watermark header yet → first post-deploy run will rebuild and stamp it.

Full live behavior (run 1 rebuilds + stamps, run 2 skips) will be confirmed against the CI-deployed version after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)