### PR TITLE
fix(function): surface index upload failures instead of swallowing

### DIFF
--- a/tools/generator/scryfall/uploadToS3.ts
+++ b/tools/generator/scryfall/uploadToS3.ts
@@ -43,6 +43,11 @@ export const uploadToS3 = async (body: Buffer | string, metadata?: Record<string
         const data = await upload.done();
         console.log(`Uploading done: ${JSON.stringify(data)}`);
     } catch (e) {
+        // Rethrow so a failed upload fails the function invocation instead of
+        // silently "succeeding" and letting index.json go stale unnoticed. The
+        // watermark is only stamped on a successful PutObject, so the next run
+        // re-detects the mismatch and retries.
         console.error(`Uploading failed: ${e}`);
+        throw e;
     }
 };


### PR DESCRIPTION
## Summary

`uploadToS3` caught upload errors, logged them, and returned normally — so a failed S3 upload reported the function invocation as **successful** and let `index.json` go stale unnoticed (the nightly trigger history would show all-green even while the index rotted).

Rethrow after logging so a failed upload fails the invocation (visible in YC function status + trigger run history).

Plays well with the freshness watermark (#91): the `x-amz-meta-scryfall-updated-at` stamp is only written on a **successful** `PutObject`, so after a failed run the next run still sees a mismatch and retries.

## Verified

Build matrix green: `npm run build`, `npm test` (12/12), `npm run build:function`, `docker compose build`. Callers checked — the function path (`generate.ts`) already wraps the upload in try/catch → rejects the invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)