### PR TITLE
fix: replace dead scg.dekker.gdn domain with live scg.dekker.lol

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tuktuk Screen Scrapper
 ---
 
 StarCityGames prices scrapper
-url: https://scg.dekker.gdn
+url: https://scg.dekker.lol
 
 ## How to run
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "tuktuk-scg-scrapper",
     "version": "0.3.0",
     "description": "The starcitygames.com shop price srapper.",
-    "homepage": "https://scg.dekker.gdn",
+    "homepage": "https://scg.dekker.lol",
     "email": "dekker25@gmail.com",
     "engines": {
         "node": ">=22.12"

--- a/tools/updater/upsert.ts
+++ b/tools/updater/upsert.ts
@@ -8,7 +8,7 @@ import { Transform } from 'stream';
 const arr = [];
 
 const fetchQueue = queue((value, callback) => {
-    fetch('https://scg.dekker.gdn/storage/card', {
+    fetch('https://scg.dekker.lol/storage/card', {
         method: 'PUT',
         body: JSON.stringify(value),
         headers: {


### PR DESCRIPTION
## Summary

`scg.dekker.gdn` no longer resolves (verified: `curl` → connection failure), while the live site is **`scg.dekker.lol`** (200, and what the deploy runbook + prod smoke already use). Updates the three stale references:

- `package.json` `homepage`
- `README.md` url
- `tools/updater/upsert.ts` — the manual upsert tool's `PUT …/storage/card` endpoint

## Verified

Build matrix green: `npm run build`, `npm test` (12/12), `npm run build:function`, `docker compose build`. String-only change, no deps/config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)